### PR TITLE
add MaxDepth in CONF

### DIFF
--- a/aggr.conf
+++ b/aggr.conf
@@ -14,6 +14,7 @@ Engine2 = ./stockfish
 EPDBook = ./book.epd
 BaseTime = 1000
 IncTime = 50
+MaxDepth = 10
 Concurrency = 4
 DrawScoreLimit = 4
 DrawMoveLimit = 8

--- a/spsa.pl
+++ b/spsa.pl
@@ -56,6 +56,7 @@ my $eng2_path        = $Config->{Engine}->{Engine2}        ; defined($eng2_path)
 my $epd_path         = $Config->{Engine}->{EPDBook}        ; defined($epd_path)         || $simulate || die "EPDBook not defined!";
 my $base_time        = $Config->{Engine}->{BaseTime}       ; defined($base_time)        || $simulate || die "BaseTime not defined!";
 my $inc_time         = $Config->{Engine}->{IncTime}        ; defined($inc_time)         || $simulate || die "IncTime not defined!";
+my $max_depth        = $Config->{Engine}->{MaxDepth}       ; defined($max_depth)        || $simulate || die "MaxDepth not defined!";
 my $threads          = $Config->{Engine}->{Concurrency}    ; defined($threads)          || $simulate || die "Concurrency not defined!";
 my $draw_score_limit = $Config->{Engine}->{DrawScoreLimit} ; defined($draw_score_limit) || $simulate || die "DrawScoreLimit not defined!";
 my $draw_move_limit  = $Config->{Engine}->{DrawMoveLimit}  ; defined($draw_move_limit)  || $simulate || die "DrawMoveLimit not defined!";
@@ -429,7 +430,7 @@ GAME:  while(1)
 
            # STEP. Let it go!
            my $t0 = time;
-           print $Curr_Writer "go wtime $wtime btime $btime winc $inc_time binc $inc_time\n";
+           print $Curr_Writer "go wtime $wtime btime $btime winc $inc_time binc $inc_time depth $max_depth\n";
 
            # STEP. Read output from engine until it prints the bestmove.
            my $score = 0;


### PR DESCRIPTION
Reducing time/inc causes problems eventually:
- communication/processing overhead
- noise from the OS and other processes, task switching etc.
- timer resolution, OS dependant (typical 10ms)
  Using a depth limit avoids these problems, and allows to reliably play
  very fast games.

On the other hand, a depth limit can be dangerous too:
- a single search explosion can block for avery long time
- the depth may be too large or too small depending on the position
  So combining the two is useful.

Typical example, when tuning eval parameters that are not really depth
dependant, would be something like tc=2+0.02 depth=10 or so. In my
experience this kind of combination gives good results, in the sense
that it gives high drawelo for a given testing throughput.
